### PR TITLE
Skip no-op Cloudflare KV writes when highest UID is unchanged

### DIFF
--- a/cmd/gmail-blade/main.go
+++ b/cmd/gmail-blade/main.go
@@ -324,7 +324,10 @@ func runOnce(
 				batchHighestUID = msg.UID
 			}
 		}
-		if batchHighestUID == 0 {
+		// Only advance and write to the cache when the batch moved the highest
+		// UID forward. Cloudflare's KV free plan caps writes at 1000/day, so
+		// skip no-op puts that would store the same value.
+		if batchHighestUID <= *highestUID {
 			continue
 		}
 		if cache != nil && !dryRun {


### PR DESCRIPTION
Cloudflare's KV free plan caps writes at 1000/day. This guards against redundant `put` calls by only writing to the cache when a batch actually moved the highest processed UID forward.

The single `batchHighestUID <= *highestUID` check subsumes the previous `== 0` early-continue (UIDs are always ≥ 1), so it covers both empty batches and any batch that didn't advance the UID.

In practice each genuinely-new unread email still produces one write, so real-world volume stays far below the cap — this just eliminates wasted no-op writes.
