### PR TITLE
Remove Cloudflare KV TTL

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,6 @@ cache:
     account_id: "0123456789abcdef"
     namespace_id: "fedcba9876543210"
     api_token: "$CLOUDFLARE_API_TOKEN"
-    # Cache lifetime (default: 2160h, or 90 days)
-    ttl: "2160h"
 
 # Optional GitHub integration
 github:

--- a/cmd/gmail-blade/cache.go
+++ b/cmd/gmail-blade/cache.go
@@ -22,7 +22,6 @@ type cloudflareKVCache struct {
 	accountID   string
 	namespaceID string
 	apiToken    string
-	ttl         time.Duration
 	baseURL     string
 	httpClient  *http.Client
 }
@@ -47,7 +46,6 @@ func newCloudflareKVCache(config configCloudflareKV) *cloudflareKVCache {
 		accountID:   config.AccountID,
 		namespaceID: config.NamespaceID,
 		apiToken:    config.APIToken,
-		ttl:         config.ttlDuration,
 		baseURL:     cloudflareAPIURL,
 		httpClient:  &http.Client{Timeout: 30 * time.Second},
 	}
@@ -106,12 +104,7 @@ func (c *cloudflareKVCache) put(ctx context.Context, imapUsername string, uid im
 		return errors.Wrap(err, "marshal value")
 	}
 
-	url := fmt.Sprintf(
-		"%s?expiration_ttl=%d",
-		c.valueURL(),
-		int64(c.ttl/time.Second),
-	)
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, bytes.NewReader(data))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, c.valueURL(), bytes.NewReader(data))
 	if err != nil {
 		return errors.Wrap(err, "create request")
 	}

--- a/cmd/gmail-blade/config.go
+++ b/cmd/gmail-blade/config.go
@@ -36,15 +36,13 @@ type configCache struct {
 }
 
 type configCloudflareKV struct {
-	AccountID   string        `yaml:"account_id"`
-	NamespaceID string        `yaml:"namespace_id"`
-	APIToken    string        `yaml:"api_token"`
-	TTL         string        `yaml:"ttl"`
-	ttlDuration time.Duration `yaml:"-"`
+	AccountID   string `yaml:"account_id"`
+	NamespaceID string `yaml:"namespace_id"`
+	APIToken    string `yaml:"api_token"`
 }
 
 func (c configCloudflareKV) enabled() bool {
-	return c.AccountID != "" || c.NamespaceID != "" || c.APIToken != "" || c.TTL != ""
+	return c.AccountID != "" || c.NamespaceID != "" || c.APIToken != ""
 }
 
 type configGitHub struct {
@@ -112,17 +110,6 @@ func parseConfig(path string) (*config, error) {
 		if c.Cache.CloudflareKV.APIToken == "" {
 			return nil, errors.New("cache.cloudflare_kv.api_token cannot be empty")
 		}
-		if c.Cache.CloudflareKV.TTL == "" {
-			c.Cache.CloudflareKV.TTL = "2160h"
-		}
-		ttl, err := time.ParseDuration(c.Cache.CloudflareKV.TTL)
-		if err != nil {
-			return nil, errors.Wrapf(err, "invalid cache.cloudflare_kv.ttl %q", c.Cache.CloudflareKV.TTL)
-		}
-		if ttl < time.Minute {
-			return nil, errors.New("cache.cloudflare_kv.ttl cannot be less than 1m")
-		}
-		c.Cache.CloudflareKV.ttlDuration = ttl
 	}
 
 	c.GitHub.PersonalAccessToken = os.ExpandEnv(c.GitHub.PersonalAccessToken)


### PR DESCRIPTION
## Summary
- write Cloudflare KV checkpoints without an expiration
- remove the obsolete TTL configuration and documentation

## Testing
- `go test -shuffle=on -v -race -coverprofile=/tmp/gmail-blade-coverage -covermode=atomic ./...`
- `golangci-lint run --timeout=30m ./...`
- `go mod tidy` (clean worktree)