### PR TITLE
ci: update Go version to 1.26

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
       - name: Check Go module tidiness
         shell: bash
         run: |
@@ -48,7 +48,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        go-version: [ 1.25.x ]
+        go-version: [ 1.26.x ]
         platform: [ ubuntu-latest, macos-latest ]
     runs-on: ${{ matrix.platform }}
     steps:


### PR DESCRIPTION
## Summary

- update the lint job to use Go 1.26.x
- update the test matrix to use Go 1.26.x

## Verification

- `git diff --check`